### PR TITLE
Allow operator pods to be scheduled on any node

### DIFF
--- a/component/namespace.jsonnet
+++ b/component/namespace.jsonnet
@@ -10,6 +10,10 @@ local params = inv.parameters.airlock_microgateway;
 {
   '00_namespace': kube.Namespace(params.namespace) {
     metadata+: {
+      annotations+: {
+        // Allow pods to be scheduled on any node
+        'openshift.io/node-selector': '',
+      },
       labels+: {
         'openshift.io/cluster-monitoring': 'true',
       },

--- a/tests/golden/defaults/airlock-microgateway/airlock-microgateway/00_prerequisites/00_namespace.yaml
+++ b/tests/golden/defaults/airlock-microgateway/airlock-microgateway/00_prerequisites/00_namespace.yaml
@@ -1,7 +1,8 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  annotations: {}
+  annotations:
+    openshift.io/node-selector: ''
   labels:
     name: syn-airlock-microgateway
     openshift.io/cluster-monitoring: 'true'


### PR DESCRIPTION
OLM installed operator pods have a node affinity for `infra` nodes which collides with the default node selector for `app` nodes. By setting an empty node-selector annotations on the namespace, pods can successfully be scheduled again.

```
kubectl get csv airlock-microgateway.v4.5.4 
NAME                          DISPLAY                VERSION   REPLACES                      PHASE
airlock-microgateway.v4.5.4   Airlock Microgateway   4.5.4     airlock-microgateway.v4.5.3   Succeeded
```
```
kubectl -n syn-airlock-microgateway get deployment airlock-microgateway-operator -oyaml | yq '.spec.template.spec.affinity'
nodeAffinity:
  requiredDuringSchedulingIgnoredDuringExecution:
    nodeSelectorTerms:
      - matchExpressions:
          - key: node-role.kubernetes.io/infra
            operator: Exists
```

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
