### PR TITLE
Create `CiliumNetworkPolicy` when Cilium is installed

### DIFF
--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -174,6 +174,9 @@ If both `spec.gatewayClassName` and `spec.infrastructure.parametersRef` are prov
 
 See the https://gateway-api.sigs.k8s.io/reference/spec/#gateway[Gateway API] and https://docs.airlock.com/microgateway/latest/index/1726159368159.html#Configuration_examples_of_K8s_Gateway_API_CRs[Airlock Microgateway] documentation for a full reference of supported configuration options for `Gateway` resources.
 
+TIP: When component `cilium` is installed in the cluster, the component also creates a `CiliumNetworkPolicy` which allows traffic from identity `world` for each managed `Gateway` resource.
+>>>>>>> 7173a80 (Create `CiliumNetworkPolicy` when Cilium is installed)
+
 === Example
 
 [source,yaml]

--- a/tests/golden/resources/airlock-microgateway/airlock-microgateway/02_resources/01_gateway_networkpolicies.yaml
+++ b/tests/golden/resources/airlock-microgateway/airlock-microgateway/02_resources/01_gateway_networkpolicies.yaml
@@ -1,0 +1,13 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: gateway-1
+  namespace: airlock
+spec:
+  endpointSelector:
+    matchLabels:
+      gateway.networking.k8s.io/gateway-name: gateway-1
+      microgateway.airlock.com/managedBy: syn-airlock-microgateway
+  ingress:
+    - fromEntities:
+        - world

--- a/tests/resources.yml
+++ b/tests/resources.yml
@@ -1,3 +1,6 @@
+applications:
+  - cilium
+
 parameters:
   airlock_microgateway:
     gateway_parameters:


### PR DESCRIPTION
This commit extends the component to create a `CiliumNetworkPolicy` which allows traffic from identity `world` to each managed `Gateway` resource when the Cilium Commodore component is installed in the cluster.

Note that this network policy is currently not customizable.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.


<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
