### PR TITLE
Deploy Airlock Microgateway license expiration alerts

### DIFF
--- a/class/airlock-microgateway.yml
+++ b/class/airlock-microgateway.yml
@@ -48,6 +48,10 @@ parameters:
             - ${_base_directory}/component/resources.jsonnet
           input_type: jsonnet
           output_path: airlock-microgateway/02_resources/
+        - input_paths:
+            - ${_base_directory}/component/alerts.jsonnet
+          input_type: jsonnet
+          output_path: airlock-microgateway/10_alerts/
 
     helm:
       dependencies:
@@ -86,6 +90,10 @@ parameters:
             - ${_base_directory}/component/resources.jsonnet
           input_type: jsonnet
           output_path: airlock-microgateway/02_resources/
+        - input_paths:
+            - ${_base_directory}/component/alerts.jsonnet
+          input_type: jsonnet
+          output_path: airlock-microgateway/10_alerts/
 
 
   kapitan:

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -46,6 +46,10 @@ parameters:
     gateway_parameters: {}
     gateways: {}
 
+    alerts:
+      ignoreNames: []
+      patches: {}
+
     # See Airlock docs: https://docs.airlock.com/microgateway/4.5/index/1726159368039.html
     helm_values:
       operator:

--- a/component/alerts.jsonnet
+++ b/component/alerts.jsonnet
@@ -1,0 +1,58 @@
+local alertpatching = import 'lib/alert-patching.libsonnet';
+local kap = import 'lib/kapitan.libjsonnet';
+local prom = import 'lib/prom.libsonnet';
+
+local inv = kap.inventory();
+local params = inv.parameters.airlock_microgateway;
+
+local operator_rules = prom.PrometheusRule('operator-rules') {
+  metadata+: {
+    namespace: params.namespace,
+  },
+  spec+: {
+    groups:
+      std.map(
+        function(g)
+          alertpatching.filterPatchRules(
+            g,
+            ignoreNames=params.alerts.ignoreNames,
+            patches=params.alerts.patches,
+            preserveRecordingRules=true,
+            patchNames=false,
+          ),
+        [
+          {
+            name: 'airlock-microgateway-license.rules',
+            rules: [
+              {
+                alert: 'AirlockMicrogatewayLicenseExpiresSoon',
+                expr: '(microgateway_license_expiry_timestamp_seconds - time()) / (60*60*24) < 30',
+                annotations: {
+                  summary: 'Airlock Microgateway license expires in less than a month',
+                  description: 'The Airlock Microgateway license expires in {{ $value|humanizeDuration }}. Contact the customer/Ergon to renew the license.',
+                },
+                labels: {
+                  severity: 'warning',
+                },
+              },
+              {
+                alert: 'AirlockMicrogatewayLicenseExpiresVerySoon',
+                expr: '(microgateway_license_expiry_timestamp_seconds - time()) / (60*60*24) < 10',
+                annotations: {
+                  summary: 'Airlock Microgateway license expires in less than 10 days',
+                  description: 'The Airlock Microgateway license expires in {{ $value|humanizeDuration }}. Contact the customer/Ergon to renew the license.',
+                },
+                labels: {
+                  severity: 'critical',
+                },
+              },
+            ],
+          },
+        ],
+      ),
+  },
+};
+
+{
+  operator_rules: operator_rules,
+}

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -346,6 +346,33 @@ airlock_microgateway:
       parametersRef: "airlock/gatewayparams"
 ----
 
+== `alerts`
+
+[horizontal]
+type:: object
+
+This parameter allows users to disable or patch alerts managed by the component.
+
+NOTE: The component currently expects that an `openshift4-monitoring`-style alert patching library is available for the target cluster's distribution's monitoring stack.
+
+
+== `alerts.ignoreNames`
+
+[horizontal]
+type:: list
+default:: `[]`
+
+Users can add alert names which they want to disable in this list.
+
+=== `alerts.patches`
+
+[horizontal]
+type:: object
+default:: `{}`
+
+Users can customize alerts through this parameter.
+The component looks for alert names it knows in this parameter, and applies the provided value, if any, over the default alert configuration.
+
 == `helm_values`
 
 [horizontal]

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -9,6 +9,12 @@ parameters:
       - type: https
         source: https://raw.githubusercontent.com/projectsyn/component-espejote/v0.11.0/lib/espejote.libsonnet
         output_path: vendor/lib/espejote.libsonnet
+      - type: https
+        source: https://raw.githubusercontent.com/appuio/component-openshift4-monitoring/v7.2.0/lib/openshift4-monitoring-prom.libsonnet
+        output_path: vendor/lib/prom.libsonnet
+      - type: https
+        source: https://raw.githubusercontent.com/appuio/component-openshift4-monitoring/v7.2.0/lib/openshift4-monitoring-alert-patching.libsonnet
+        output_path: vendor/lib/alert-patching.libsonnet
 
   airlock_microgateway:
     gateway_listener_manager:

--- a/tests/disable-gateway-api.yml
+++ b/tests/disable-gateway-api.yml
@@ -1,6 +1,15 @@
 # Overwrite parameters here
 
 parameters:
+  kapitan:
+    dependencies:
+      - type: https
+        source: https://raw.githubusercontent.com/appuio/component-openshift4-monitoring/v7.2.0/lib/openshift4-monitoring-prom.libsonnet
+        output_path: vendor/lib/prom.libsonnet
+      - type: https
+        source: https://raw.githubusercontent.com/appuio/component-openshift4-monitoring/v7.2.0/lib/openshift4-monitoring-alert-patching.libsonnet
+        output_path: vendor/lib/alert-patching.libsonnet
+
   airlock_microgateway:
     gateway_api:
       enabled: false

--- a/tests/golden/defaults/airlock-microgateway/airlock-microgateway/10_alerts/operator_rules.yaml
+++ b/tests/golden/defaults/airlock-microgateway/airlock-microgateway/10_alerts/operator_rules.yaml
@@ -1,0 +1,34 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations: {}
+  labels:
+    name: operator-rules
+  name: operator-rules
+  namespace: syn-airlock-microgateway
+spec:
+  groups:
+    - name: airlock-microgateway-license.rules
+      rules:
+        - alert: AirlockMicrogatewayLicenseExpiresSoon
+          annotations:
+            description: The Airlock Microgateway license expires in {{ $value|humanizeDuration
+              }}. Contact the customer/Ergon to renew the license.
+            summary: Airlock Microgateway license expires in less than a month
+          expr: (microgateway_license_expiry_timestamp_seconds - time()) / (60*60*24)
+            < 30
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: airlock-microgateway
+        - alert: AirlockMicrogatewayLicenseExpiresVerySoon
+          annotations:
+            description: The Airlock Microgateway license expires in {{ $value|humanizeDuration
+              }}. Contact the customer/Ergon to renew the license.
+            summary: Airlock Microgateway license expires in less than 10 days
+          expr: (microgateway_license_expiry_timestamp_seconds - time()) / (60*60*24)
+            < 10
+          labels:
+            severity: critical
+            syn: 'true'
+            syn_component: airlock-microgateway

--- a/tests/golden/disable-gateway-api/airlock-microgateway/airlock-microgateway/10_alerts/operator_rules.yaml
+++ b/tests/golden/disable-gateway-api/airlock-microgateway/airlock-microgateway/10_alerts/operator_rules.yaml
@@ -1,0 +1,34 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations: {}
+  labels:
+    name: operator-rules
+  name: operator-rules
+  namespace: syn-airlock-microgateway
+spec:
+  groups:
+    - name: airlock-microgateway-license.rules
+      rules:
+        - alert: AirlockMicrogatewayLicenseExpiresSoon
+          annotations:
+            description: The Airlock Microgateway license expires in {{ $value|humanizeDuration
+              }}. Contact the customer/Ergon to renew the license.
+            summary: Airlock Microgateway license expires in less than a month
+          expr: (microgateway_license_expiry_timestamp_seconds - time()) / (60*60*24)
+            < 30
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: airlock-microgateway
+        - alert: AirlockMicrogatewayLicenseExpiresVerySoon
+          annotations:
+            description: The Airlock Microgateway license expires in {{ $value|humanizeDuration
+              }}. Contact the customer/Ergon to renew the license.
+            summary: Airlock Microgateway license expires in less than 10 days
+          expr: (microgateway_license_expiry_timestamp_seconds - time()) / (60*60*24)
+            < 10
+          labels:
+            severity: critical
+            syn: 'true'
+            syn_component: airlock-microgateway

--- a/tests/golden/olm/airlock-microgateway/airlock-microgateway/10_alerts/operator_rules.yaml
+++ b/tests/golden/olm/airlock-microgateway/airlock-microgateway/10_alerts/operator_rules.yaml
@@ -1,0 +1,34 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations: {}
+  labels:
+    name: operator-rules
+  name: operator-rules
+  namespace: syn-airlock-microgateway
+spec:
+  groups:
+    - name: airlock-microgateway-license.rules
+      rules:
+        - alert: AirlockMicrogatewayLicenseExpiresSoon
+          annotations:
+            description: The Airlock Microgateway license expires in {{ $value|humanizeDuration
+              }}. Contact the customer/Ergon to renew the license.
+            summary: Airlock Microgateway license expires in less than a month
+          expr: (microgateway_license_expiry_timestamp_seconds - time()) / (60*60*24)
+            < 30
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: airlock-microgateway
+        - alert: AirlockMicrogatewayLicenseExpiresVerySoon
+          annotations:
+            description: The Airlock Microgateway license expires in {{ $value|humanizeDuration
+              }}. Contact the customer/Ergon to renew the license.
+            summary: Airlock Microgateway license expires in less than 10 days
+          expr: (microgateway_license_expiry_timestamp_seconds - time()) / (60*60*24)
+            < 10
+          labels:
+            severity: critical
+            syn: 'true'
+            syn_component: airlock-microgateway

--- a/tests/golden/resources/airlock-microgateway/airlock-microgateway/10_alerts/operator_rules.yaml
+++ b/tests/golden/resources/airlock-microgateway/airlock-microgateway/10_alerts/operator_rules.yaml
@@ -1,0 +1,34 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations: {}
+  labels:
+    name: operator-rules
+  name: operator-rules
+  namespace: syn-airlock-microgateway
+spec:
+  groups:
+    - name: airlock-microgateway-license.rules
+      rules:
+        - alert: AirlockMicrogatewayLicenseExpiresSoon
+          annotations:
+            description: The Airlock Microgateway license expires in {{ $value|humanizeDuration
+              }}. Contact the customer/Ergon to renew the license.
+            summary: Airlock Microgateway license expires in less than a month
+          expr: (microgateway_license_expiry_timestamp_seconds - time()) / (60*60*24)
+            < 30
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: airlock-microgateway
+        - alert: AirlockMicrogatewayLicenseExpiresVerySoon
+          annotations:
+            description: The Airlock Microgateway license expires in {{ $value|humanizeDuration
+              }}. Contact the customer/Ergon to renew the license.
+            summary: Airlock Microgateway license expires in less than 10 days
+          expr: (microgateway_license_expiry_timestamp_seconds - time()) / (60*60*24)
+            < 10
+          labels:
+            severity: critical
+            syn: 'true'
+            syn_component: airlock-microgateway

--- a/tests/olm.yml
+++ b/tests/olm.yml
@@ -6,6 +6,12 @@ parameters:
       - type: https
         source: https://raw.githubusercontent.com/appuio/component-openshift4-operators/master/lib/openshift4-operators.libsonnet
         output_path: vendor/lib/openshift4-operators.libsonnet
+      - type: https
+        source: https://raw.githubusercontent.com/appuio/component-openshift4-monitoring/v7.2.0/lib/openshift4-monitoring-prom.libsonnet
+        output_path: vendor/lib/prom.libsonnet
+      - type: https
+        source: https://raw.githubusercontent.com/appuio/component-openshift4-monitoring/v7.2.0/lib/openshift4-monitoring-alert-patching.libsonnet
+        output_path: vendor/lib/alert-patching.libsonnet
 
   airlock_microgateway:
     install_method: olm

--- a/tests/resources.yml
+++ b/tests/resources.yml
@@ -2,6 +2,15 @@ applications:
   - cilium
 
 parameters:
+  kapitan:
+    dependencies:
+      - type: https
+        source: https://raw.githubusercontent.com/appuio/component-openshift4-monitoring/v7.2.0/lib/openshift4-monitoring-prom.libsonnet
+        output_path: vendor/lib/prom.libsonnet
+      - type: https
+        source: https://raw.githubusercontent.com/appuio/component-openshift4-monitoring/v7.2.0/lib/openshift4-monitoring-alert-patching.libsonnet
+        output_path: vendor/lib/alert-patching.libsonnet
+
   airlock_microgateway:
     gateway_parameters:
       airlock/params:


### PR DESCRIPTION
We configure two alerts for the license expiration: a warning alert which starts firing 30 days before expiry, and a critical alert which starts firing 10 days before expiry.

The implementation expects that the target cluster's distribution's monitoring stack's Commodore component provides a `openshift4-monitoring`-style alert patching library.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
